### PR TITLE
rework nrpe config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "roles/monitored/files/monitoring"]
+	path = roles/monitored/files/monitoring
+	url = https://github.com/sown/monitoring.git

--- a/roles/monitored/tasks/nrpe-install.yml
+++ b/roles/monitored/tasks/nrpe-install.yml
@@ -8,6 +8,13 @@
     state: present
   become: true
 
+- name: Install packages for checks
+  apt:
+    name:
+      - debsums
+    state: present
+  become: true
+
 - name: Enable NRPE server
   service:
     name: nagios-nrpe-server
@@ -31,6 +38,35 @@
     owner: root
     group: root
     mode: 0644
+  notify:
+    - Reload Nagios NRPE server
+  become: true
+
+- name: Deploy SOWN checks
+  copy:
+    src: "{{item.src}}"
+    dest: /usr/local/lib/nagios/plugins/{{item.path}}
+    owner: root
+    group: root
+    mode: 0755
+  with_filetree: monitoring/checks
+
+- name: Remove old nrpe.d files
+  file:
+    path: "/etc/nagios/nrpe.d/{{ item }}.cfg"
+    state: absent
+  with_items:
+    - users
+    - load
+    - processes
+    - nrpe
+    - debsums
+    - uname
+    - uptime
+    - apt
+    - mail
+    - ipv6
+    - systemd
   notify:
     - Reload Nagios NRPE server
   become: true

--- a/roles/monitored/tasks/nrpe-install.yml
+++ b/roles/monitored/tasks/nrpe-install.yml
@@ -44,12 +44,12 @@
 
 - name: Deploy SOWN checks
   copy:
-    src: "{{item.src}}"
-    dest: /usr/local/lib/nagios/plugins/{{item.path}}
+    src: "{{ item.src }}"
+    dest: /usr/local/lib/nagios/plugins/{{ item.path }}
     owner: root
     group: root
     mode: 0755
-  with_filetree: monitoring/checks
+  with_filetree: monitoring/checks/
 
 - name: Remove old nrpe.d files
   file:

--- a/roles/monitored/tasks/nrpe-install.yml
+++ b/roles/monitored/tasks/nrpe-install.yml
@@ -62,6 +62,7 @@
     - nrpe
     - debsums
     - uname
+    - kernel
     - uptime
     - apt
     - mail

--- a/roles/monitored/tasks/nrpe-install.yml
+++ b/roles/monitored/tasks/nrpe-install.yml
@@ -49,7 +49,7 @@
     owner: root
     group: root
     mode: 0755
-  with_filetree: monitoring/checks/
+  with_filetree: monitoring/checks/ # noqa 104 ansible-lint#582
 
 - name: Remove old nrpe.d files
   file:

--- a/roles/monitored/templates/nrpe_local.cfg.j2
+++ b/roles/monitored/templates/nrpe_local.cfg.j2
@@ -1,7 +1,6 @@
 # this file is managed by the ansible "monitored" role
 # please do not modify by hand
 allowed_hosts={{ ",".join(nrpe_allowed_ips) }}
-debug=1
 command_timeout=600
 connection_timeout=900
 

--- a/roles/monitored/vars/main.yml
+++ b/roles/monitored/vars/main.yml
@@ -1,12 +1,12 @@
 nrpe_allowed_ips:
   - 127.0.0.1
   - ::1
-  - 10.5.0.243  # Monitor
-  - 152.78.103.164  # Monitor
-  - 2001:630:d0:f700::243  # Monitor
-  - 10.5.0.215  # Monitor 2
-  - 152.78.103.187  # Monitor 2
-  - 2001:630:d0:f700::215  # Monitor 2
+  - 10.5.0.243  # monitor
+  - 152.78.103.164  # monitor
+  - 2001:630:d0:f700::243  # monitor
+  - 10.5.0.215  # monitor2
+  - 152.78.103.187  # monitor2
+  - 2001:630:d0:f700::215  # monitor2
 nrpe_checks:
   users:
     check: "/usr/lib/nagios/plugins/check_users"


### PR DESCRIPTION
This reworks the NRPE configuration, following on from most of the bits @trickeydan started last week, to build a single large file for each host, eg see below.

This allows for nicely generating it from vars and doing overrides per host (eg bumping procs limits on VM hosts, etc). It also means that all the config left in nrpe.d will be custom per-host.

```
root@netbox:~# cat /etc/nagios/nrpe_local.cfg
# this file is managed by the ansible "monitored" role
# please do not modify by hand
allowed_hosts=127.0.0.1,::1,10.5.0.243,152.78.103.164,2001:630:d0:f700::243,10.5.0.215,152.78.103.187,2001:630:d0:f700::215
debug=1
command_timeout=600
connection_timeout=900

command[check_load] = /usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
command[check_uptime] = /usr/bin/uptime 
command[check_users] = /usr/lib/nagios/plugins/check_users -w 10 -c 20
command[check_internal_ipv6_addresses] = /usr/local/lib/nagios/plugins/check_internal_ipv6_addresses 
command[check_nrpe] = /usr/lib/nagios/plugins/check_dummy 0 'NRPE is running'
command[check_reboot] = /usr/local/lib/nagios/plugins/check_reboot 
command[check_uname] = /bin/uname -rv
command[check_systemd] = /usr/local/lib/nagios/plugins/check_systemd 
command[check_total_procs] = /usr/lib/nagios/plugins/check_procs -w 250 -c 300
command[check_zombie_procs] = /usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
command[check_mail] = /usr/local/lib/nagios/plugins/check_mail 
command[check_debsums] = /usr/local/lib/nagios/plugins/check_debsums 
command[check_packages] = /usr/local/lib/nagios/plugins/check_packages 
```