### PR TITLE
sort checks to make them consistent on all hosts

### DIFF
--- a/roles/monitored/templates/nrpe_local.cfg.j2
+++ b/roles/monitored/templates/nrpe_local.cfg.j2
@@ -4,6 +4,6 @@ allowed_hosts={{ ",".join(nrpe_allowed_ips) }}
 command_timeout=600
 connection_timeout=900
 
-{% for name, details in nrpe_checks.items() %}
+{% for name, details in nrpe_checks.items()|sort %}
 command[check_{{name}}] = {{details.check}} {{details.arguments|default("")}}
 {% endfor %}


### PR DESCRIPTION
This caused ansible to get confused sometimes when things were in a different order to what it expected