### PR TITLE
exclude zepler from upgrades for now

### DIFF
--- a/host_vars/ZEPLER.yml
+++ b/host_vars/ZEPLER.yml
@@ -1,0 +1,3 @@
+# this box is in a strange state with backports
+# don't do unattended upgrades
+unattended_upgrades: false


### PR DESCRIPTION
This needs sorting out, but only once we have physical access again.