### PR TITLE
generate NRPE config to monitor IPMI via GW servers

### DIFF
--- a/roles/monitored/tasks/nrpe-install.yml
+++ b/roles/monitored/tasks/nrpe-install.yml
@@ -42,6 +42,17 @@
     - Reload Nagios NRPE server
   become: true
 
+- name: Deploy NRPE IPMI bits TODO move to GW role
+  template:
+    src: nrpe_ipmi.cfg.j2
+    dest: /etc/nagios/nrpe.d/ipmi.cfg
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Reload Nagios NRPE server
+  become: true
+
 - name: Deploy SOWN checks
   copy:
     src: "{{ item.src }}"

--- a/roles/monitored/templates/nrpe_ipmi.cfg.j2
+++ b/roles/monitored/templates/nrpe_ipmi.cfg.j2
@@ -1,0 +1,5 @@
+# this file is managed by the ansible "monitored" role
+# please do not modify by hand
+{% for host in hostvars %}
+command[check_ipmi_{{host|lower}}] = /usr/lib/nagios/plugins/check_ping -H {{host|lower}}-ipmi -w 1000,50% -c 1000,50%
+{% endfor %}


### PR DESCRIPTION
This shouldn't actually be here, we should put it in the GW role when we write it