### PR TITLE
automatically set up PSU monitoring, for sown/tasks#39

### DIFF
--- a/group_vars/device_roles_backup-server.yml
+++ b/group_vars/device_roles_backup-server.yml
@@ -1,2 +1,4 @@
 # Backup servers are not accessable from shared access boxes
 add_ssh_gateway_keys: false
+# Servers are only single PSU
+psu_monitoring: false

--- a/host_vars/ZEPLER.yml
+++ b/host_vars/ZEPLER.yml
@@ -1,3 +1,4 @@
 # this box is in a strange state with backports
 # don't do unattended upgrades
 unattended_upgrades: false
+psu_monitoring: false

--- a/roles/monitored/tasks/main.yml
+++ b/roles/monitored/tasks/main.yml
@@ -1,2 +1,10 @@
 - import_tasks: nrpe-install.yml
   tags: nrpe
+- name: fetch host details
+  tags: nrpe_psu
+  setup:
+- import_tasks: psu.yml
+  tags: nrpe_psu
+  when:
+    - "ansible_facts['virtualization_role'] in ('NA', 'host')"  # physical machines
+    - "psu_monitoring|default(true)"  # we allow opting out of this eg for single psu machines

--- a/roles/monitored/tasks/psu.yml
+++ b/roles/monitored/tasks/psu.yml
@@ -1,0 +1,14 @@
+- name: Install ipmitool (for check_psu)
+  apt:
+    name: ipmitool
+    state: present
+  become: true
+- name: Add check_psu sudo config
+  copy:
+    dest: /etc/sudoers.d/check_psu
+    mode: "644"
+    content: |
+      Defaults:nagios !requiretty
+      nagios ALL=(root) NOPASSWD: /usr/bin/ipmitool -c sdr type Power\ Supply
+      nagios ALL=(root) NOPASSWD: /usr/bin/ipmitool -c sdr type Current
+      nagios ALL=(root) NOPASSWD: /usr/bin/ipmitool -c sdr type Voltage


### PR DESCRIPTION
(we've already had this for a while, but only on VMS hosts, the sudo config was previously done by hand)