### PR TITLE
check_procs only for non-kernel threads

### DIFF
--- a/roles/monitored/vars/main.yml
+++ b/roles/monitored/vars/main.yml
@@ -16,7 +16,7 @@ nrpe_checks:
     arguments: "-w 15,10,5 -c 30,25,20"
   total_procs:
     check: "/usr/lib/nagios/plugins/check_procs"
-    arguments: "-w 250 -c 300"
+    arguments: "-k -w 100 -c 150"
   zombie_procs:
     check: "/usr/lib/nagios/plugins/check_procs"
     arguments: "-w 5 -c 10 -s Z"


### PR DESCRIPTION
Some servers have lots of kernel thread processes, which rather skews the check.  `-k` flag only considers non-kernel threads.  This means critical and warning limits can be reduced to 150 and 100 (from 300 and 250).