### PR TITLE
remove lxd installer from incus hosts

### DIFF
--- a/roles/vms/tasks/main.yml
+++ b/roles/vms/tasks/main.yml
@@ -13,3 +13,8 @@
 - name: Install incus
   apt:
     name: incus
+
+- name: Uninstall lxd-installer
+  apt:
+    name: lxd-installer
+    state: absent


### PR DESCRIPTION
this provides an annoying `lxc` binary which downloads and installs lxd

unhelpfully though this will remove the `ubuntu-server` metapackage, it seems we can get away with that though, eg autoremove afterwards doesn't want to delete half the system