### PR TITLE
remove auth2 SSH key from all servers

### DIFF
--- a/roles/sown_common/tasks/ssh-auth.yml
+++ b/roles/sown_common/tasks/ssh-auth.yml
@@ -2,10 +2,11 @@
 - name: Add ssh gateway keys
   ansible.posix.authorized_key:
     user: root
-    state: present
+    state: "{{ item.state | default('present') }}"
     key: "{{ lookup('file', item.key) }}"
   with_items:
-    - key: sown-auth2.pub
     - key: sown-login.pub
     - key: sown-login2.pub
+    - key: sown-auth2.pub
+      state: absent
   when: add_ssh_gateway_keys is undefined or add_ssh_gateway_keys


### PR DESCRIPTION
now we've switched over to using the login servers for a long time