### PR TITLE
Excludes tracefs type from check_disk

### DIFF
--- a/roles/monitored/vars/main.yml
+++ b/roles/monitored/vars/main.yml
@@ -55,4 +55,4 @@ nrpe_checks:  # noqa var-naming[no-role-prefix]
     arguments: -w 2:2 -c 1:2 -C keepalived
   disks:
     check: /usr/lib/nagios/plugins/check_disk
-    arguments: -w 20% -c 10% -X tmpfs -X overlay -X devtmpfs -X nsfs -X squashfs -x /tmp -x /var/tmp -x /run/lxd_config/9p
+    arguments: -w 20% -c 10% -X tmpfs -X overlay -X devtmpfs -X nsfs -X squashfs -X tracefs -x /tmp -x /var/tmp -x /run/lxd_config/9p


### PR DESCRIPTION
VMS-B32-1 complains it cannot access filesystem at /sys/kernel/debug/tracing.  This looks to be a tracefs filesystem.  There is no good reason to monitor this so we should exlcude tracefs from the default check_disk NRPE check.