### PR TITLE
Ensures Incus disks are ignored

### DIFF
--- a/roles/monitored/vars/main.yml
+++ b/roles/monitored/vars/main.yml
@@ -55,4 +55,4 @@ nrpe_checks:  # noqa var-naming[no-role-prefix]
     arguments: -w 2:2 -c 1:2 -C keepalived
   disks:
     check: /usr/lib/nagios/plugins/check_disk
-    arguments: -w 20% -c 10% -X tmpfs -X overlay -X devtmpfs -X nsfs -X squashfs -X tracefs -x /tmp -x /var/tmp -x /run/lxd_config/9p
+    arguments: -w 20% -c 10% -A -X tmpfs -X overlay -X devtmpfs -X nsfs -X squashfs -X tracefs -x /tmp -x /var/tmp -i /var/lib/incus


### PR DESCRIPTION
Now we have moved from LXD to Incus the ignore matching for the disks check no longer works and all the Incus VM disks are attempted to be monitored but cannot be read by NRPE.  However, like the LXD disks the reporting for these provides not useful information so should be ignored. 